### PR TITLE
Add initial Qt skeleton project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+project(vast LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+add_library(vast_lib
+    src/MainWindow.cpp
+    src/FrameLoader.cpp
+    src/PluginManager.cpp
+    src/ArtifactDetector.cpp
+)
+
+target_include_directories(vast_lib PUBLIC include)
+
+target_link_libraries(vast_lib PUBLIC Qt6::Widgets)
+
+add_executable(vast
+    src/main.cpp
+)
+
+target_link_libraries(vast PRIVATE vast_lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,60 @@
 cmake_minimum_required(VERSION 3.16)
-project(vast LANGUAGES CXX)
+project(vast LANGUAGES CXX CUDA)
+
+include(CPack)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 COMPONENTS Widgets REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil libswscale)
+find_package(CUDA REQUIRED)
+
+include(FetchContent)
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
+
 
 add_library(vast_lib
     src/MainWindow.cpp
     src/FrameLoader.cpp
     src/PluginManager.cpp
     src/ArtifactDetector.cpp
+    src/ReportGenerator.cpp
+    src/detectors/blur_detector.cu
 )
 
 target_include_directories(vast_lib PUBLIC include)
 
-target_link_libraries(vast_lib PUBLIC Qt6::Widgets)
+target_link_libraries(vast_lib PUBLIC Qt6::Widgets PkgConfig::FFMPEG CUDA::cuda_driver)
 
 add_executable(vast
     src/main.cpp
 )
 
 target_link_libraries(vast PRIVATE vast_lib)
+
+add_subdirectory(plugins/example)
+
+install(TARGETS vast DESTINATION bin)
+install(TARGETS vast_lib DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include)
+
+set(CPACK_GENERATOR "ZIP;TGZ")
+set(CPACK_PACKAGE_NAME "VAST")
+set(CPACK_PACKAGE_VERSION "0.1")
+set(CPACK_PACKAGE_CONTACT "")
+include(CPack)
+
+enable_testing()
+add_executable(vast_tests tests/test_frameloader.cpp)
+target_link_libraries(vast_tests PRIVATE vast_lib Catch2::Catch2WithMain)
+add_test(NAME vast_tests COMMAND vast_tests)

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 # VAST
 
-This repository contains an initial skeleton for the VAST application.
+VAST is a GPU accelerated tool for video artifact detection. It uses Qt 6 for
+its interface and FFmpeg for video decoding. Plugins can extend the detection
+capabilities at runtime.
 
 ## Building
 
@@ -10,4 +12,36 @@ cmake ..
 make
 ```
 
-Qt 6 and FFmpeg development packages are required for building.
+Qt 6, FFmpeg and CUDA development packages are required for building.
+
+### Packaging
+
+To generate a portable archive with all binaries run:
+
+```
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . --target package
+```
+
+The resulting archive under `build/` contains the application and the example
+detector plugin in `plugins/`.
+
+### Plugin API
+
+Plugins are shared libraries that export a `createDetector` function returning
+an instance of `ArtifactDetector`.
+
+```
+extern "C" ArtifactDetector* createDetector();
+```
+
+The shared library is placed in the `plugins/` directory next to the
+executable.
+
+### Running Tests
+
+From the `build/` directory run:
+
+```
+ctest
+```

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,13 @@
-Readme
+# VAST
+
+This repository contains an initial skeleton for the VAST application.
+
+## Building
+
+```
+mkdir build && cd build
+cmake ..
+make
+```
+
+Qt 6 and FFmpeg development packages are required for building.

--- a/include/ArtifactDetector.h
+++ b/include/ArtifactDetector.h
@@ -1,0 +1,15 @@
+#ifndef VAST_ARTIFACTDETECTOR_H
+#define VAST_ARTIFACTDETECTOR_H
+
+#include <QObject>
+#include <QString>
+
+class ArtifactDetector : public QObject {
+  Q_OBJECT
+public:
+  explicit ArtifactDetector(QObject* parent = nullptr) : QObject(parent) {}
+  virtual QString name() const = 0;
+  virtual void processFrame(const unsigned char* data, int width, int height) = 0;
+};
+
+#endif // VAST_ARTIFACTDETECTOR_H

--- a/include/ArtifactDetector.h
+++ b/include/ArtifactDetector.h
@@ -8,8 +8,11 @@ class ArtifactDetector : public QObject {
   Q_OBJECT
 public:
   explicit ArtifactDetector(QObject* parent = nullptr) : QObject(parent) {}
+  virtual ~ArtifactDetector() = default;
   virtual QString name() const = 0;
+  virtual bool initialize(int width, int height) = 0;
   virtual void processFrame(const unsigned char* data, int width, int height) = 0;
+  virtual float lastScore() const = 0;
 };
 
 #endif // VAST_ARTIFACTDETECTOR_H

--- a/include/FrameLoader.h
+++ b/include/FrameLoader.h
@@ -1,0 +1,19 @@
+#ifndef VAST_FRAMELOADER_H
+#define VAST_FRAMELOADER_H
+
+#include <QObject>
+#include <QString>
+#include <vector>
+
+class FrameLoader : public QObject {
+  Q_OBJECT
+public:
+  explicit FrameLoader(QObject* parent = nullptr);
+  bool loadVideo(const QString& path);
+  std::vector<unsigned char> getFrame(int index);
+
+private:
+  QString m_path;
+};
+
+#endif // VAST_FRAMELOADER_H

--- a/include/FrameLoader.h
+++ b/include/FrameLoader.h
@@ -4,16 +4,39 @@
 #include <QObject>
 #include <QString>
 #include <vector>
+#include <mutex>
+
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libswscale/swscale.h>
+}
 
 class FrameLoader : public QObject {
   Q_OBJECT
 public:
   explicit FrameLoader(QObject* parent = nullptr);
+  ~FrameLoader();
   bool loadVideo(const QString& path);
   std::vector<unsigned char> getFrame(int index);
 
+  int width() const { return m_width; }
+  int height() const { return m_height; }
+
+signals:
+  void errorOccurred(const QString& msg);
+
 private:
   QString m_path;
+  AVFormatContext* m_fmtCtx = nullptr;
+  AVCodecContext* m_codecCtx = nullptr;
+  int m_videoStream = -1;
+  AVFrame* m_frame = nullptr;
+  AVPacket* m_packet = nullptr;
+  SwsContext* m_sws = nullptr;
+  int m_width = 0;
+  int m_height = 0;
+  std::mutex m_mutex;
 };
 
 #endif // VAST_FRAMELOADER_H

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -1,0 +1,12 @@
+#ifndef VAST_MAINWINDOW_H
+#define VAST_MAINWINDOW_H
+
+#include <QMainWindow>
+
+class MainWindow : public QMainWindow {
+  Q_OBJECT
+public:
+  explicit MainWindow(QWidget* parent = nullptr);
+};
+
+#endif // VAST_MAINWINDOW_H

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -2,11 +2,23 @@
 #define VAST_MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QLabel>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include "FrameLoader.h"
 
 class MainWindow : public QMainWindow {
   Q_OBJECT
 public:
   explicit MainWindow(QWidget* parent = nullptr);
+
+protected:
+  void dragEnterEvent(QDragEnterEvent* event) override;
+  void dropEvent(QDropEvent* event) override;
+
+private:
+  FrameLoader m_loader;
+  QLabel* m_label = nullptr;
 };
 
 #endif // VAST_MAINWINDOW_H

--- a/include/PluginManager.h
+++ b/include/PluginManager.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QString>
 #include <vector>
+#include <QLibrary>
 
 class ArtifactDetector;
 
@@ -11,11 +12,13 @@ class PluginManager : public QObject {
   Q_OBJECT
 public:
   explicit PluginManager(QObject* parent = nullptr);
+  ~PluginManager();
   bool loadPlugin(const QString& path);
   std::vector<ArtifactDetector*> detectors() const;
 
 private:
   std::vector<ArtifactDetector*> m_detectors;
+  std::vector<QLibrary*> m_libs;
 };
 
 #endif // VAST_PLUGINMANAGER_H

--- a/include/PluginManager.h
+++ b/include/PluginManager.h
@@ -1,0 +1,21 @@
+#ifndef VAST_PLUGINMANAGER_H
+#define VAST_PLUGINMANAGER_H
+
+#include <QObject>
+#include <QString>
+#include <vector>
+
+class ArtifactDetector;
+
+class PluginManager : public QObject {
+  Q_OBJECT
+public:
+  explicit PluginManager(QObject* parent = nullptr);
+  bool loadPlugin(const QString& path);
+  std::vector<ArtifactDetector*> detectors() const;
+
+private:
+  std::vector<ArtifactDetector*> m_detectors;
+};
+
+#endif // VAST_PLUGINMANAGER_H

--- a/include/ReportGenerator.h
+++ b/include/ReportGenerator.h
@@ -1,0 +1,12 @@
+#ifndef VAST_REPORTGENERATOR_H
+#define VAST_REPORTGENERATOR_H
+
+#include <QString>
+#include <vector>
+
+class ReportGenerator {
+public:
+    bool generateHtml(const QString& file, const std::vector<QString>& images);
+};
+
+#endif // VAST_REPORTGENERATOR_H

--- a/plugins/example/CMakeLists.txt
+++ b/plugins/example/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(example_detector SHARED example_detector.cpp)
+
+target_include_directories(example_detector PRIVATE ${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(example_detector PRIVATE Qt6::Widgets)
+
+set_target_properties(example_detector PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins
+)
+install(TARGETS example_detector DESTINATION plugins)

--- a/plugins/example/example_detector.cpp
+++ b/plugins/example/example_detector.cpp
@@ -1,0 +1,15 @@
+#include "ArtifactDetector.h"
+#include <QString>
+#include <QtGlobal>
+
+class ExampleDetector : public ArtifactDetector {
+public:
+    QString name() const override { return "ExampleDetector"; }
+    bool initialize(int width, int height) override { Q_UNUSED(width); Q_UNUSED(height); return true; }
+    void processFrame(const unsigned char*, int, int) override {}
+    float lastScore() const override { return 0.f; }
+};
+
+extern "C" ArtifactDetector* createDetector() {
+    return new ExampleDetector();
+}

--- a/src/ArtifactDetector.cpp
+++ b/src/ArtifactDetector.cpp
@@ -1,0 +1,3 @@
+#include "ArtifactDetector.h"
+
+// base class has no implementation

--- a/src/FrameLoader.cpp
+++ b/src/FrameLoader.cpp
@@ -1,0 +1,15 @@
+#include "FrameLoader.h"
+
+FrameLoader::FrameLoader(QObject* parent)
+    : QObject(parent) {}
+
+bool FrameLoader::loadVideo(const QString& path) {
+    m_path = path;
+    // TODO: implement ffmpeg loading
+    return true;
+}
+
+std::vector<unsigned char> FrameLoader::getFrame(int index) {
+    // TODO: return decoded frame bytes
+    return {};
+}

--- a/src/FrameLoader.cpp
+++ b/src/FrameLoader.cpp
@@ -1,15 +1,117 @@
 #include "FrameLoader.h"
 
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libswscale/swscale.h>
+}
+
+#include <QDebug>
+#include <mutex>
+
 FrameLoader::FrameLoader(QObject* parent)
     : QObject(parent) {}
 
+FrameLoader::~FrameLoader() {
+    if (m_frame)
+        av_frame_free(&m_frame);
+    if (m_packet)
+        av_packet_free(&m_packet);
+    if (m_codecCtx)
+        avcodec_free_context(&m_codecCtx);
+    if (m_fmtCtx)
+        avformat_close_input(&m_fmtCtx);
+    if (m_sws)
+        sws_freeContext(m_sws);
+}
+
 bool FrameLoader::loadVideo(const QString& path) {
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_path = path;
-    // TODO: implement ffmpeg loading
+
+    avformat_network_init();
+
+    if (avformat_open_input(&m_fmtCtx, path.toUtf8().constData(), nullptr, nullptr) < 0) {
+        emit errorOccurred("Could not open input");
+        return false;
+    }
+
+    if (avformat_find_stream_info(m_fmtCtx, nullptr) < 0) {
+        emit errorOccurred("Could not find stream info");
+        return false;
+    }
+
+    for (unsigned i = 0; i < m_fmtCtx->nb_streams; ++i) {
+        if (m_fmtCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+            m_videoStream = i;
+            break;
+        }
+    }
+    if (m_videoStream == -1) {
+        emit errorOccurred("No video stream found");
+        return false;
+    }
+
+    AVCodecParameters* params = m_fmtCtx->streams[m_videoStream]->codecpar;
+    const AVCodec* codec = avcodec_find_decoder(params->codec_id);
+    if (!codec) {
+        emit errorOccurred("Unsupported codec");
+        return false;
+    }
+
+    m_codecCtx = avcodec_alloc_context3(codec);
+    if (avcodec_parameters_to_context(m_codecCtx, params) < 0) {
+        emit errorOccurred("Failed to copy codec parameters");
+        return false;
+    }
+
+    if (avcodec_open2(m_codecCtx, codec, nullptr) < 0) {
+        emit errorOccurred("Could not open codec");
+        return false;
+    }
+
+    m_width = m_codecCtx->width;
+    m_height = m_codecCtx->height;
+
+    m_frame = av_frame_alloc();
+    m_packet = av_packet_alloc();
+    m_sws = sws_getContext(m_width, m_height, m_codecCtx->pix_fmt,
+                           m_width, m_height, AV_PIX_FMT_RGB24, SWS_BILINEAR,
+                           nullptr, nullptr, nullptr);
+
     return true;
 }
 
 std::vector<unsigned char> FrameLoader::getFrame(int index) {
-    // TODO: return decoded frame bytes
-    return {};
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_fmtCtx)
+        return {};
+
+    if (av_seek_frame(m_fmtCtx, m_videoStream, index, AVSEEK_FLAG_FRAME) < 0) {
+        emit errorOccurred("Seek failed");
+        return {};
+    }
+    avcodec_flush_buffers(m_codecCtx);
+
+    int gotFrame = 0;
+    while (!gotFrame && av_read_frame(m_fmtCtx, m_packet) >= 0) {
+        if (m_packet->stream_index == m_videoStream) {
+            if (avcodec_send_packet(m_codecCtx, m_packet) == 0) {
+                if (avcodec_receive_frame(m_codecCtx, m_frame) == 0) {
+                    gotFrame = 1;
+                }
+            }
+        }
+        av_packet_unref(m_packet);
+    }
+
+    if (!gotFrame)
+        return {};
+
+    std::vector<unsigned char> rgb(m_width * m_height * 3);
+    uint8_t* dest[4] = { rgb.data(), nullptr, nullptr, nullptr };
+    int linesize[4] = { m_width * 3, 0, 0, 0 };
+    sws_scale(m_sws, m_frame->data, m_frame->linesize, 0, m_height, dest, linesize);
+
+    return rgb;
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,0 +1,6 @@
+#include "MainWindow.h"
+
+MainWindow::MainWindow(QWidget* parent)
+    : QMainWindow(parent) {
+    setWindowTitle("VAST");
+}

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,6 +1,41 @@
 #include "MainWindow.h"
+#include <QDragEnterEvent>
+#include <QMimeData>
+#include <QImage>
+#include <QPixmap>
+#include <QVBoxLayout>
+#include <QDebug>
+
+#include "FrameLoader.h"
 
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent) {
     setWindowTitle("VAST");
+    setAcceptDrops(true);
+
+    QWidget* central = new QWidget(this);
+    QVBoxLayout* layout = new QVBoxLayout(central);
+    m_label = new QLabel(tr("Drop video file here"), central);
+    m_label->setAlignment(Qt::AlignCenter);
+    layout->addWidget(m_label);
+    setCentralWidget(central);
+}
+
+void MainWindow::dragEnterEvent(QDragEnterEvent* event) {
+    if (event->mimeData()->hasUrls())
+        event->acceptProposedAction();
+}
+
+void MainWindow::dropEvent(QDropEvent* event) {
+    const QUrl url = event->mimeData()->urls().value(0);
+    if (!url.isLocalFile())
+        return;
+
+    if (m_loader.loadVideo(url.toLocalFile())) {
+        auto frame = m_loader.getFrame(0);
+        if (!frame.empty()) {
+            QImage img(frame.data(), m_loader.width(), m_loader.height(), QImage::Format_RGB888);
+            m_label->setPixmap(QPixmap::fromImage(img));
+        }
+    }
 }

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1,0 +1,13 @@
+#include "PluginManager.h"
+
+PluginManager::PluginManager(QObject* parent)
+    : QObject(parent) {}
+
+bool PluginManager::loadPlugin(const QString& path) {
+    // TODO: dynamically load plugin and register detectors
+    return true;
+}
+
+std::vector<ArtifactDetector*> PluginManager::detectors() const {
+    return m_detectors;
+}

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1,11 +1,48 @@
 #include "PluginManager.h"
+#include "ArtifactDetector.h"
+
+#include <QLibrary>
+#include <QDebug>
 
 PluginManager::PluginManager(QObject* parent)
     : QObject(parent) {}
 
+PluginManager::~PluginManager() {
+    for (auto* lib : m_libs) {
+        if (lib->isLoaded())
+            lib->unload();
+        delete lib;
+    }
+    for (auto* det : m_detectors)
+        delete det;
+}
+
 bool PluginManager::loadPlugin(const QString& path) {
-    // TODO: dynamically load plugin and register detectors
-    return true;
+    QLibrary* lib = new QLibrary(path);
+    if (!lib->load()) {
+        qWarning() << "Failed to load plugin" << path << lib->errorString();
+        delete lib;
+        return false;
+    }
+
+    using CreateFn = ArtifactDetector*(*)();
+    CreateFn create = (CreateFn)lib->resolve("createDetector");
+    if (!create) {
+        qWarning() << "Invalid plugin" << path;
+        lib->unload();
+        delete lib;
+        return false;
+    }
+
+    ArtifactDetector* det = create();
+    if (det) {
+        m_detectors.push_back(det);
+        m_libs.push_back(lib);
+        return true;
+    }
+    lib->unload();
+    delete lib;
+    return false;
 }
 
 std::vector<ArtifactDetector*> PluginManager::detectors() const {

--- a/src/ReportGenerator.cpp
+++ b/src/ReportGenerator.cpp
@@ -1,0 +1,17 @@
+#include "ReportGenerator.h"
+#include <QFile>
+#include <QTextStream>
+
+bool ReportGenerator::generateHtml(const QString& file, const std::vector<QString>& images)
+{
+    QFile f(file);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
+        return false;
+    QTextStream out(&f);
+    out << "<html><body>\n";
+    for (const auto& img : images) {
+        out << "<img src='" << img << "'/><br/>\n";
+    }
+    out << "</body></html>\n";
+    return true;
+}

--- a/src/detectors/blur_detector.cu
+++ b/src/detectors/blur_detector.cu
@@ -1,0 +1,12 @@
+extern "C" __global__ void blur_kernel(const unsigned char* src, unsigned char* dst, int width, int height)
+{
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= width || y >= height)
+        return;
+    // dummy kernel: copy src to dst
+    int idx = (y * width + x) * 3;
+    dst[idx] = src[idx];
+    dst[idx+1] = src[idx+1];
+    dst[idx+2] = src[idx+2];
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,11 @@
+#include <QApplication>
+#include "MainWindow.h"
+
+int main(int argc, char* argv[]) {
+    QApplication app(argc, argv);
+
+    MainWindow w;
+    w.show();
+
+    return app.exec();
+}

--- a/tests/test_frameloader.cpp
+++ b/tests/test_frameloader.cpp
@@ -1,0 +1,8 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include "FrameLoader.h"
+
+TEST_CASE("FrameLoader handles invalid file", "[frameloader]") {
+    FrameLoader loader;
+    REQUIRE_FALSE(loader.loadVideo("nonexistent.mp4"));
+}


### PR DESCRIPTION
## Summary
- set up CMake project
- add skeleton classes for MainWindow, FrameLoader, PluginManager
- add base class for ArtifactDetector
- create basic main application
- update README with build instructions

## Testing
- `cmake ..` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684895d0a734832694babddc730d8d28