### PR TITLE
Add basic Qt project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.5)
+project(vast LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find Qt
+find_package(Qt6 COMPONENTS Widgets QUIET)
+if(NOT Qt6_FOUND)
+  find_package(Qt5 REQUIRED COMPONENTS Widgets)
+  set(QT_VERSION 5)
+else()
+  set(QT_VERSION 6)
+endif()
+
+if(QT_VERSION EQUAL 6)
+  set(QT_LIBS Qt6::Widgets)
+else()
+  set(QT_LIBS Qt5::Widgets)
+endif()
+
+add_executable(vast src/main.cpp)
+
+target_link_libraries(vast PRIVATE ${QT_LIBS})
+
+target_include_directories(vast PUBLIC include)
+
+install(TARGETS vast RUNTIME DESTINATION bin)

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,14 @@
-Readme
+# VAST
+
+This project contains a minimal Qt-based application that opens an empty window titled "VAST".
+
+## Building
+
+The project uses CMake. Qt 5 or Qt 6 development packages must be installed. On Linux, build with:
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+On Windows using Visual Studio generator, run the above commands from the Visual Studio developer prompt.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,10 @@
+#include <QApplication>
+#include <QMainWindow>
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+    QMainWindow window;
+    window.setWindowTitle("VAST");
+    window.show();
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- set up CMake build using Qt5/Qt6
- add minimal Qt application opening an empty window titled "VAST"
- add build instructions in README

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt5 or Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684897e1c4d88326a75ff38024bedf55